### PR TITLE
Add new fields for communicating per-component pay rates in RP14a

### DIFF
--- a/Schemas/RP14A.xsd
+++ b/Schemas/RP14A.xsd
@@ -108,8 +108,9 @@
 																<!-- Placeholder for components where it's not relevant -->
 																<xsd:enumeration value="No rate defined in law" />
 
-																<!-- Placeholder for future interim processes, not used in HP-->
+																<!-- Placeholder for interim processes -->
 																<xsd:enumeration value="Data not yet available" />
+																<xsd:enumeration value="Data to be requested from IP" />
 
 																<!-- Reasons 52 week rate doesn't apply -->
 																<xsd:enumeration value="Fixed rate of pay" />

--- a/Schemas/RP14A.xsd
+++ b/Schemas/RP14A.xsd
@@ -57,6 +57,70 @@
 											</xsd:simpleType>
 										</xsd:element>
 										
+										<xsd:element name="ComponentPayPerWeek" minOccurs="0" maxOccurs="8">
+											<xsd:annotation>
+												<xsd:documentation>Override for base pay when calculating a component rate.</xsd:documentation>
+											</xsd:annotation>
+
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1">
+														<xsd:simpleType>
+															<xsd:restriction base="xsd:string">
+																<xsd:enumeration value="Redundancy Pay"/>
+																<xsd:enumeration value="Arrears of Pay"/>
+																<xsd:enumeration value="Holiday Pay Taken Not Paid"/>
+																<xsd:enumeration value="Holiday Pay Accrued"/>
+																<xsd:enumeration value="Protective Award"/>
+																<xsd:enumeration value="Compensatory Notice Pay"/>
+																<xsd:enumeration value="Refund of Notional Tax"/>
+																<xsd:enumeration value="Basic Award"/>
+																<xsd:enumeration value="Notice Worked Not Paid"/>
+															</xsd:restriction>
+														</xsd:simpleType>
+													</xsd:element>
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1">
+														<xsd:simpleType>
+															<xsd:union>
+																<xsd:simpleType>
+																	<xsd:restriction base="xsd:decimal">
+																		<xsd:fractionDigits value="2"/>
+																	</xsd:restriction>
+																</xsd:simpleType>
+																<xsd:simpleType>
+																	<xsd:restriction base="xsd:string">
+																		<xsd:whiteSpace value="collapse"/>
+																		<xsd:length value="0"/>
+																	</xsd:restriction>
+																</xsd:simpleType>
+															</xsd:union>
+														</xsd:simpleType>
+													</xsd:element>
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" default="Rate provided">
+														<xsd:annotation>
+															<xsd:documentation>If the component rate is available, and if not, why.</xsd:documentation>
+														</xsd:annotation>
+														<xsd:simpleType>
+															<xsd:restriction base="xsd:string">
+																<!-- Rate has been provided in ComponentRate -->
+																<xsd:enumeration value="Rate provided"/>
+
+																<!-- Placeholder for components where it's not relevant -->
+																<xsd:enumeration value="No rate defined in law" />
+
+																<!-- Placeholder for future interim processes, not used in HP-->
+																<xsd:enumeration value="Data not yet available" />
+
+																<!-- Reasons 52 week rate doesn't apply -->
+																<xsd:enumeration value="Fixed rate of pay" />
+																<xsd:enumeration value="No holiday pay payable"/>
+															</xsd:restriction>
+														</xsd:simpleType>
+													</xsd:element>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+									
 										<xsd:element name="WeeklyPayDay" minOccurs="0">
 											<xsd:annotation>
 												<xsd:documentation>Pay day, if paid weekly. </xsd:documentation>

--- a/Schemas/RP14A.xsd
+++ b/Schemas/RP14A.xsd
@@ -141,7 +141,7 @@
 	</xsd:element>
 	<xsd:simpleType name="NinoType">
 		<xsd:restriction base="xsd:string">
-      <xsd:pattern value="(?!BG|GB|NK|KN|TN|NT|ZZ|bg|gb|nk|kn|tn|nt|zz)[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
+			<xsd:pattern value="[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
 		</xsd:restriction>
 	</xsd:simpleType>
   <xsd:simpleType name="CaseReferenceType">

--- a/Schemas/RP14A_Flattened.xsd
+++ b/Schemas/RP14A_Flattened.xsd
@@ -57,6 +57,88 @@
 											</xsd:simpleType>
 										</xsd:element>
 										
+										<xsd:element name="ComponentPayPerWeek1" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+										<xsd:element name="ComponentPayPerWeek2" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+										<xsd:element name="ComponentPayPerWeek3" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+										<xsd:element name="ComponentPayPerWeek4" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+										<xsd:element name="ComponentPayPerWeek5" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+										<xsd:element name="ComponentPayPerWeek6" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+										<xsd:element name="ComponentPayPerWeek7" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+										<xsd:element name="ComponentPayPerWeek8" minOccurs="0" maxOccurs="1">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="ComponentType" minOccurs="1" maxOccurs="1" type="ComponentType" />
+													<xsd:element name="ComponentRate" minOccurs="0" maxOccurs="1" type="OptionalCurrencyType" />
+													<xsd:element name="ComponentRateStatus" minOccurs="1" maxOccurs="1" type="ComponentRateStatusType" default="Rate provided"/>
+												</xsd:sequence>
+											</xsd:complexType>
+										</xsd:element>
+
+
+
 										<xsd:element name="WeeklyPayDay" minOccurs="0">
 											<xsd:annotation>
 												<xsd:documentation>Pay day, if paid weekly. </xsd:documentation>
@@ -267,4 +349,41 @@
 			<xsd:element name="Title" type="xsd:string" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
+	<xsd:simpleType name="ComponentType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Redundancy Pay"/>
+			<xsd:enumeration value="Arrears of Pay"/>
+			<xsd:enumeration value="Holiday Pay Taken Not Paid"/>
+			<xsd:enumeration value="Holiday Pay Accrued"/>
+			<xsd:enumeration value="Protective Award"/>
+			<xsd:enumeration value="Compensatory Notice Pay"/>
+			<xsd:enumeration value="Refund of Notional Tax"/>
+			<xsd:enumeration value="Basic Award"/>
+			<xsd:enumeration value="Notice Worked Not Paid"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="ComponentRateStatusType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Rate provided"/>
+			<xsd:enumeration value="No rate defined in law" />
+			<xsd:enumeration value="Data not yet available" />
+			<xsd:enumeration value="Fixed rate of pay" />
+			<xsd:enumeration value="No holiday pay payable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="OptionalCurrencyType">
+		<xsd:union>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:decimal">
+					<xsd:fractionDigits value="2"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:whiteSpace value="collapse"/>
+					<xsd:length value="0"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:union>
+	</xsd:simpleType>
 </xsd:schema>

--- a/Schemas/RP14A_Flattened.xsd
+++ b/Schemas/RP14A_Flattened.xsd
@@ -246,7 +246,7 @@
 	</xsd:element>
 	<xsd:simpleType name="NinoType">
 		<xsd:restriction base="xsd:string">
-      <xsd:pattern value="(?!BG|GB|NK|KN|TN|NT|ZZ|bg|gb|nk|kn|tn|nt|zz)[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
+			<xsd:pattern value="[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
 		</xsd:restriction>
 	</xsd:simpleType>
   <xsd:simpleType name="CaseReferenceType">

--- a/Schemas/RP14A_Flattened.xsd
+++ b/Schemas/RP14A_Flattened.xsd
@@ -367,6 +367,7 @@
 			<xsd:enumeration value="Rate provided"/>
 			<xsd:enumeration value="No rate defined in law" />
 			<xsd:enumeration value="Data not yet available" />
+			<xsd:enumeration value="Data to be requested from IP" />
 			<xsd:enumeration value="Fixed rate of pay" />
 			<xsd:enumeration value="No holiday pay payable"/>
 		</xsd:restriction>


### PR DESCRIPTION
The RP14a schema includes information about a claimant's rate of pay. In UKSI 2018 No. 1378 a new requirement was added to collect the average rate of pay following a 52-week reference period for claimants who work variable hours or for variable rates of pay, for use in calculating holiday pay related awards.

This change allows multiple specific components of the pay award to have their rate of pay specified directly, to allow for the 52 week rate to be supplied for these claimants.

There is also a validation improvement for National Insurance numbers.