### PR TITLE
APP-772: Update NINO validator to enforce suffix letter presence

### DIFF
--- a/Schemas/RP14.xsd
+++ b/Schemas/RP14.xsd
@@ -335,7 +335,7 @@
 	</xsd:element>
 	<xsd:simpleType name="NinoType">
 		<xsd:restriction base="xsd:string">
-			<xsd:pattern value="(?!BG|GB|NK|KN|TN|NT|ZZ|bg|gb|nk|kn|tn|nt|zz)[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
+			<xsd:pattern value="(?!BG|GB|NK|KN|TN|NT|ZZ|bg|gb|nk|kn|tn|nt|zz)[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{1}"/>
 		</xsd:restriction>
 	</xsd:simpleType>
   <xsd:simpleType name="CaseReferenceType">

--- a/Schemas/RP14A.xsd
+++ b/Schemas/RP14A.xsd
@@ -206,7 +206,7 @@
 	</xsd:element>
 	<xsd:simpleType name="NinoType">
 		<xsd:restriction base="xsd:string">
-			<xsd:pattern value="[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
+			<xsd:pattern value="[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{1}"/>
 		</xsd:restriction>
 	</xsd:simpleType>
   <xsd:simpleType name="CaseReferenceType">

--- a/Schemas/RP14A_Flattened.xsd
+++ b/Schemas/RP14A_Flattened.xsd
@@ -328,7 +328,7 @@
 	</xsd:element>
 	<xsd:simpleType name="NinoType">
 		<xsd:restriction base="xsd:string">
-			<xsd:pattern value="[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
+			<xsd:pattern value="[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{1}"/>
 		</xsd:restriction>
 	</xsd:simpleType>
   <xsd:simpleType name="CaseReferenceType">

--- a/Schemas/RP14_Flattened.xsd
+++ b/Schemas/RP14_Flattened.xsd
@@ -836,7 +836,7 @@
 	</xsd:element>
 	<xsd:simpleType name="NinoType">
 		<xsd:restriction base="xsd:string">
-      <xsd:pattern value="(?!BG|GB|NK|KN|TN|NT|ZZ|bg|gb|nk|kn|tn|nt|zz)[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}"/>
+      <xsd:pattern value="(?!BG|GB|NK|KN|TN|NT|ZZ|bg|gb|nk|kn|tn|nt|zz)[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{1}"/>
 		</xsd:restriction>
 	</xsd:simpleType>
   <xsd:simpleType name="CaseReferenceType">


### PR DESCRIPTION
This is a bugfix to the NINO Type used by the RP14 and RP14a to enforce the presence of a single suffix character consisting of A, B, C, D, F or M. Previously, this character was optional.

This change will take effect on Tuesday 3rd August 2021 after close of business.